### PR TITLE
modofu dev pull - Do not fail when the remote image does not exist

### DIFF
--- a/helpers/modofu-real
+++ b/helpers/modofu-real
@@ -430,7 +430,7 @@ pull_devel_env()
   echo "I: Pulling fresh images for development environment..." 1>&2
   provide_basic_informations
 
-  docker-compose pull
+  docker-compose pull --ignore-pull-failures
 }
 
 


### PR DESCRIPTION
Currently:
On Linux the command stops after the first missing image.

Expected behaviour:
Just inform about the missing image, but continue to pull the other images.