### PR TITLE
added option to bypass startup scripts

### DIFF
--- a/helpers/modofu-real
+++ b/helpers/modofu-real
@@ -329,6 +329,13 @@ start_devel_env()
     fi
   done
 
+  if [ $1 = true ] ; then
+    run_startup_scripts
+  fi
+}
+
+run_startup_scripts()
+{
   # Run start.d in each container
   echo "" 1>&2
   echo "I: Running '/modofu/start.d/*' within each container..." 1>&2
@@ -543,7 +550,24 @@ case "$1" in
       ;;
 
       start)
-        start_devel_env
+        load_scripts=true
+        shift 2
+        while :;
+        do
+          case $1 in
+
+            --no-scripts)
+              load_scripts=false
+            ;;
+
+            *)
+              break;
+            ;;
+          esac
+          shift
+        done
+
+        start_devel_env $load_scripts
         devel_env_info
       ;;
 


### PR DESCRIPTION
Added the flag `--no-scripts` that can be used when starting the dev environment in order to bypass the scripts like composer install and yarn install that take a long time